### PR TITLE
Remove animated show/hide on small screen

### DIFF
--- a/src/StoryPage.js
+++ b/src/StoryPage.js
@@ -4,10 +4,8 @@ import StoryVideoCard from "./components/StoryVideoCard";
 
 const StoryPage = () => {
   const markups = `
-        <section class="w-full h-screen flex justify-center items-center gap-20">
-            <div class="hidden xl:block">
-                ${StoryCard({})}
-            </div>
+        <section class="w-full h-screen flex flex-col-reverse xl:flex-row justify-center items-center gap-10 xl:gap-20 p-4">          
+            ${StoryCard({})}
             ${StoryVideoCard({})}
         </section>
     `;

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -3,7 +3,7 @@ import { html } from "../lib";
 const Layout = ({ page }) => {
   return html`
     <div
-      class="w-full h-screen p-0 m-0 text-white bg-[#F15C22] lg:bg-gradient-to-r lg:from-[#F15C22] lg:from-0% lg:via-[#F7931D] lg:via-50% lg:to-[#FFC840] lg:to-100%"
+      class="p-0 m-0 text-white bg-[#F15C22] lg:bg-gradient-to-r lg:from-[#F15C22] lg:from-0% lg:via-[#F7931D] lg:via-50% lg:to-[#FFC840] lg:to-100%"
     >
       ${page}
     </div>

--- a/src/components/StoryCard.js
+++ b/src/components/StoryCard.js
@@ -9,16 +9,22 @@ const StoryCard = ({}) => {
                 ${CardActionButton({ action: "previous" })}          
                 ${CardActionButton({ action: "next" })}
             </div>
-            <div class="w-full px-0 xl:p-0">
-                <h1 class="hidden xl:inline-block text-[46px] font-bold font-sans leading-[43px] tracking-tight mb-6">The Roberts Family's Story</h1>
-                <p class="mb-12 lg:mb-7 text-lg md:text-3xl xl:text-base leading-[23px] font-normal ">
+            <div class="w-full mb-8 px-0 xl:px-0">
+                <h1 class="inline-block font-bold font-sans text-3xl lg:text-[46px] leading-3xl lg:leading-[43px] tracking-tight mb-4 xl:mb-6">The Roberts Family's Story</h1>
+                <p class=" text-lg md:text-3xl xl:text-base leading-[23px] font-normal ">
                     The circumstances that might leat to homelessness can include 
                     loss of income or transportation,
                     a falling out with loved ones, or an abrupt economic downturn.
                     For Brandon and Jennifer, it was all of these things.
                 </p>
             </div>
-            <div class="hidden xl:flex justify-start m-0">
+
+            <div class="flex justify-center gap-8 mx-2 mb-8 xl:hidden">
+                ${CardActionButton({ action: "previous" })}                
+                ${CardActionButton({ action: "next" })}
+            </div>
+
+            <div class="flex justify-center xl:justify-start m-0">
                 ${PrimaryButton({
                   id: "one",
                   tag: "button",
@@ -26,10 +32,6 @@ const StoryCard = ({}) => {
                   label: "More Client Stories ",
                   callback: () => console.log("it deleguates to document!"),
                 })}
-            </div>
-            <div class="flex justify-between mx-2 my-0 xl:hidden">
-                ${CardActionButton({ action: "previous" })}                
-                ${CardActionButton({ action: "next" })}
             </div>
         </div>
     `;

--- a/src/components/StoryVideoCard.js
+++ b/src/components/StoryVideoCard.js
@@ -1,7 +1,5 @@
 import { html, delegateEvent, reactive } from "../lib";
-import PrimaryButton from "./PrimaryButton";
 import PlayButton from "./PlayButton";
-import StoryCard from "./StoryCard";
 import ImageSwitcher from "./ImageSwitcher";
 
 const StoryVideoCard = ({}) => {
@@ -39,66 +37,14 @@ const StoryVideoCard = ({}) => {
     .join(" ");
 
   const markups = `
-    <div class="flex flex-col justify-center items-center gap-5 w-full h-screen xl:mt-[2.3555rem] xl:w-auto xl:h-auto">            
-      <div class="w-full px-4 flex justify-between gap-4 xl:hidden show-story-card-ctl">
-        <h1 class="text-4xl leading-4xl md:text-6xl md:leading-6xl font-bold font-sans tracking-tight show-story-card-ctl">          
-          The Roberts Family's Story
-        </h1>
-        <!-- <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"  class="size-8 text-[#262861] show-story-card-ctl">
-          <path d="M11.25 4.533A9.707 9.707 0 0 0 6 3a9.735 9.735 0 0 0-3.25.555.75.75 0 0 0-.5.707v14.25a.75.75 0 0 0 1 .707A8.237 8.237 0 0 1 6 18.75c1.995 0 3.823.707 5.25 1.886V4.533ZM12.75 20.636A8.214 8.214 0 0 1 18 18.75c.966 0 1.89.166 2.75.47a.75.75 0 0 0 1-.708V4.262a.75.75 0 0 0-.5-.707A9.735 9.735 0 0 0 18 3a9.707 9.707 0 0 0-5.25 1.533v16.103Z" />
-        </svg> -->
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-8 text-[#262861] show-story-card-ctl">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 0 0-1.883 2.542l.857 6a2.25 2.25 0 0 0 2.227 1.932H19.05a2.25 2.25 0 0 0 2.227-1.932l.857-6a2.25 2.25 0 0 0-1.883-2.542m-16.5 0V6A2.25 2.25 0 0 1 6 3.75h3.879a1.5 1.5 0 0 1 1.06.44l2.122 2.12a1.5 1.5 0 0 0 1.06.44H18A2.25 2.25 0 0 1 20.25 9v.776" />
-        </svg>
-
-
-      </div>
-      <div id="card-body" class="px-4 transition-all duration-300 ease-in-out translate-y-0">
+    <div class="flex flex-col justify-center items-center gap-5 w-auto h-auto xl:mt-[2.3555rem]">
+      <div id="card-body" class="transition-all duration-300 ease-in-out translate-y-0">
         ${storyImages}        
       </div>
-            
-      <div id="images-switcher" class="flex justify-start gap-2 px-4 w-full z-10">
+      <div id="images-switcher" class="flex justify-center xl:justify-start gap-2 w-full xl:mt-2">
         ${storyImagesSwitchButtons}
       </div>
-        <div class="flex justify-center mt-10 xl:hidden">
-          ${PrimaryButton({
-            id: "one",
-            tag: "button",
-            selector: "one",
-            label: "More Client Stories ",
-            callback: () => console.log("Navigating to stories page..."),
-          })}
-        </div>
-    </div> 
-    `;
-
-  const isStoryCardVisible = reactive(false);
-
-  isStoryCardVisible.subscribe((value) => {
-    const cardBodyDiv = document.getElementById("card-body");
-    const imagesSwitcherDiv = document.getElementById("images-switcher");
-
-    cardBodyDiv.classList.add("translate-y-12");
-
-    const wait = setTimeout(() => {
-      clearTimeout(wait);
-
-      if (!value) {
-        cardBodyDiv.innerHTML = storyImages;
-        imagesSwitcherDiv.innerHTML = storyImagesSwitchButtons;
-      } else {
-        cardBodyDiv.innerHTML = StoryCard({});
-        imagesSwitcherDiv.innerHTML = "";
-      }
-
-      cardBodyDiv.classList.remove("translate-y-12");
-      cardBodyDiv.classList.add("translate-y-0");
-    }, 300);
-  });
-
-  delegateEvent("click", ".show-story-card-ctl", () => {
-    isStoryCardVisible.set(!isStoryCardVisible.get());
-  });
+    </div>`;
 
   return html`${markups}`;
 };

--- a/src/components/StoryVideoCard.js
+++ b/src/components/StoryVideoCard.js
@@ -11,14 +11,14 @@ const StoryVideoCard = ({}) => {
 
   const imagesMarkup = imagesUrls
     .map((imageUrl) => {
-      return `<img src="${imageUrl}" class="w-11/12 xl:w-auto h-auto xl:h-[29.586rem] flex-none rounded snap-center" />`;
+      return `<img src="${imageUrl}" class="w-full xl:w-11/12 h-auto xl:h-[29.586rem] flex-none rounded snap-center" />`;
     })
     .join(" ");
 
   const storyImages = `
     <div class="relative">
       <div class="w-full xl:w-[50rem] overflow-x-auto scrollbar-hidden">
-        <div class="flex flex-nowrap space-x-2 xl:space-x-8 snap-x">
+        <div class="flex flex-nowrap space-x-4 xl:space-x-8 snap-x">
           ${imagesMarkup}
         </div>
       </div>
@@ -38,7 +38,7 @@ const StoryVideoCard = ({}) => {
 
   const markups = `
     <div class="flex flex-col justify-center items-center gap-5 w-auto h-auto xl:mt-[2.3555rem]">
-      <div id="card-body" class="transition-all duration-300 ease-in-out translate-y-0">
+      <div id="card-body" class="rounded overflow-hidden">
         ${storyImages}        
       </div>
       <div id="images-switcher" class="flex justify-center xl:justify-start gap-2 w-full xl:mt-2">


### PR DESCRIPTION
<!--
Branches may use the following prefixes:

feat - A new feature
fix - Bug fix
chore - usually for test coverage or non-user touching item

Followed by feature/component/content the changes affect in parentheses.

-->
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

## 📃 Summary
Looking for opportunities for animations, small screens were showing either story text or images with a button to play video of the family's story. After reflecting on the result, I thought it is not worth it and decide to remove animations and always show both story text and images, like on big screens.

## 👀 Steps to QA
1. Run `npm install && npm run dev`
2. Visit localhost:[port] 
3. Open dev tools and try different devices

<!--
  Please provide a step-by-step list of actions in order to QA these changes.
-->

## 🎰 Risk Factors
None
<!--
Some questions that may help:
  - What are some related components that may break?
  - Are there any side effects to the changes you've made?
  - Will these changes break anything?
-->

## ✅ Checklist

<!-- MANDATORY -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

<!-- OPTIONAL
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
-->

## 🎆 Screenshots

<!---
(if user facing feature)

Before After snippet:

|Before|After|
|-|-|
| <image> | <image> |

-->